### PR TITLE
Add a config class to configure how columns are selected

### DIFF
--- a/backend/gradio_leaderboard/__init__.py
+++ b/backend/gradio_leaderboard/__init__.py
@@ -1,3 +1,3 @@
-from .leaderboard import Leaderboard, SearchColumns
+from .leaderboard import Leaderboard, SearchColumns, SelectColumns
 
-__all__ = ["Leaderboard", "SearchColumns"]
+__all__ = ["Leaderboard", "SearchColumns", "SelectColumns"]

--- a/backend/gradio_leaderboard/leaderboard.py
+++ b/backend/gradio_leaderboard/leaderboard.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import semantic_version
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from gradio.components import Component
 from gradio.data_classes import GradioModel
@@ -29,6 +29,18 @@ if TYPE_CHECKING:
 class SearchColumns:
     primary_column: str
     secondary_columns: Optional[List[str]]
+    label: Optional[str] = None
+    placeholder: Optional[str] = None
+
+
+@dataclass
+class SelectColumns:
+    default_selection: Optional[list[str]] = field(default_factory=list)
+    cant_deselect: Optional[list[str]] = field(default_factory=list)
+    allow: bool = True
+    label: Optional[str] = None
+    show_label: bool = True
+    info: Optional[str] = None
 
 
 class DataframeData(GradioModel):
@@ -53,10 +65,9 @@ class Leaderboard(Component):
         *,
         datatype: str | list[str] = "str",
         search_columns: list[str] | SearchColumns | None = None,
+        select_columns: SelectColumns | None = None,
         filter_columns: list[str] | None = None,
         hide_columns: list[str] | None = None,
-        allow_column_select: bool = True,
-        on_load_columns: list[str] | None = None,
         latex_delimiters: list[dict[str, str | bool]] | None = None,
         label: str | None = None,
         show_label: bool | None = None,
@@ -101,12 +112,11 @@ class Leaderboard(Component):
         self.headers = [str(s) for s in value.columns]
         self.datatype = datatype
         self.search_columns = self._get_search_columns(search_columns)
+        self.select_columns_config = select_columns or SelectColumns()
         self.filter_columns = filter_columns or []
         self.hide_columns = hide_columns or []
-        self.on_load_columns = on_load_columns or []
         self.col_count = (len(self.headers), "fixed")
         self.row_count = (value.shape[0], "fixed")
-        self.allow_column_select = allow_column_select
 
         if latex_delimiters is None:
             latex_delimiters = [{"left": "$$", "right": "$$", "display": True}]
@@ -151,6 +161,7 @@ class Leaderboard(Component):
             "row_count": self.row_count,
             "col_count": self.col_count,
             "headers": self.headers,
+            "select_columns_config": self.select_columns_config,
             **super().get_config(),
         }
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -1,5 +1,5 @@
 import gradio as gr
-from gradio_leaderboard import Leaderboard
+from gradio_leaderboard import Leaderboard, SelectColumns
 import config
 from pathlib import Path
 import pandas as pd
@@ -24,8 +24,11 @@ with gr.Blocks() as demo:
     """)
     Leaderboard(
         value=df,
-        allow_column_select=True,
-        on_load_columns=config.ON_LOAD_COLUMNS,
+        select_columns=SelectColumns(
+            default_selection=config.ON_LOAD_COLUMNS,
+            cant_deselect=["T", "Model"],
+            label="Select Columns to Display:",
+        ),
         search_columns=["model_name_for_query", "Type"],
         hide_columns=["model_name_for_query", "Model Size"],
         filter_columns=config.FILTER_COLUMNS,

--- a/frontend/shared/utils.ts
+++ b/frontend/shared/utils.ts
@@ -9,3 +9,11 @@ export type SearchColumns = {
 	primary_column: string | null;
 	secondary_columns: string[];
 }
+export type SelectColumns = {
+	default_selection: string[];
+    cant_deselect: string[];
+    allow: boolean;
+    label: string | null;
+    show_label: boolean;
+    info: string | null;
+}


### PR DESCRIPTION
Adds a SelectColumns class to configure how column selection should happen. 

API Reference:
```python
@dataclass
class SelectColumns:
    default_selection: Optional[list[str]] = field(default_factory=list)
    cant_deselect: Optional[list[str]] = field(default_factory=list)
    allow: bool = True
    label: Optional[str] = None
    show_label: bool = True
    info: Optional[str] = None
```



Usage:
```python
    Leaderboard(
        value=df,
        select_columns=SelectColumns(
            default_selection=config.ON_LOAD_COLUMNS,
            cant_deselect=["T", "Model"],
            label="Select Columns to Display:",
        ),
        search_columns=["model_name_for_query", "Type"],
        hide_columns=["model_name_for_query", "Model Size"],
        filter_columns=config.FILTER_COLUMNS,
        datatype=config.TYPES,
        column_widths=["2%", "33%"],
    )
```
